### PR TITLE
[docker] Add docker with demo file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ pip install -e .
 * To test on live video: `python face_alignment_test.py [-i webcam_index]`
 * To test on a video file: `python face_alignment_test.py [-i input_file] [-o output_file]`
 
+### Docker
+You can run a containerized demo using Docker. It will install the needed dependencies and allow you to test the FANPredictor on a sample image.
+
+`docker build -t ibug-face_alignment -f ./demo/Dockerfile . && docker run -it --rm ibug-face_alignment`
+You will automatically enter a tmux session and run demo.py script. If you don't want this, you can either kill it immediately or provide "--entrypoint /bin/bash" to the docker run command.
+
+Please install Docker using [the official instructions](https://docs.docker.com/get-docker/)
+
 ## How to Use
 ```python
 # Import the libraries

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,0 +1,22 @@
+FROM continuumio/miniconda3:4.12.0
+
+RUN apt update && apt upgrade -y && \
+    apt install -y \
+        libgl1 \
+        lsof \ 
+        tmux \
+        vim
+
+WORKDIR /face_alignment
+
+COPY ../requirements.txt .
+RUN pip install -r requirements.txt && \
+    pip install scikit-image
+
+COPY ../setup.py .
+COPY ../ibug ibug 
+RUN pip install -e .
+
+COPY demo/main.py .
+
+CMD ["tmux", "new-session", "/bin/bash", ";", "new-window", "python -i main.py"]

--- a/demo/main.py
+++ b/demo/main.py
@@ -1,0 +1,25 @@
+import os
+import cv2
+import torch
+from ibug.face_alignment import FANPredictor
+from skimage.data import astronaut
+import numpy as np
+
+image = astronaut()
+gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+face_cascade = cv2.CascadeClassifier(os.path.join(cv2.data.haarcascades, "haarcascade_frontalface_default.xml"))
+detections = face_cascade.detectMultiScale(gray)
+assert len(detections) == 1, "Please submit an image with exactly one clear frontal face"
+x, y, w, h = detections[0]
+detection = np.array([x, y, x+w, y+h])
+
+
+
+config = FANPredictor.create_config(gamma = 1.0, radius = 0.1, use_jit = False)
+
+device = "cpu"
+if torch.cuda.is_available():
+    device = torch.cuda.current_device()
+fan = FANPredictor(device=device, model=FANPredictor.get_model('2dfan2_alt'), config=config)
+
+landmarks, scores = fan(image, detection)


### PR DESCRIPTION
Add a dockerfile which installs the prereqs.
When built and ran, User will automatically enter a tmux session with FAN predicting the Astronaut sklearn image When built and ran, User will automatically enter a tmux session with FAN predicting the Astronaut sklearn image, this behaviour can be changed in future commits.

Detector used for now is simply the HaarCascade from opencv.

Next steps:
- Either build a flask server with UploadImage button, detects the face and draws the landmarks
- Or a jupyter notebook with a similar functionality
- Script the model, currently I cannot do it because _modules is an issue in HourGlass
- I haven't yet tested on GPUs, I believe I need to detect the gpu in bash and pass them using --gpus all